### PR TITLE
improving support for CORS by handling preflight request and configurable allowed headers header

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ func initApp() {
 		MiddlewareStack = append(MiddlewareStack, JwtMiddleware(config.PrestConf.JWTKey))
 	}
 	if config.PrestConf.CORSAllowOrigin != nil {
-		MiddlewareStack = append(MiddlewareStack, Cors(config.PrestConf.CORSAllowOrigin))
+		MiddlewareStack = append(MiddlewareStack, Cors(config.PrestConf.CORSAllowOrigin, config.PrestConf.CORSAllowHeaders))
 	}
 	app = negroni.New(MiddlewareStack...)
 }

--- a/middlewares.go
+++ b/middlewares.go
@@ -62,14 +62,18 @@ func JwtMiddleware(key string) negroni.Handler {
 }
 
 // Cors middleware
-func Cors(origin []string) negroni.Handler {
+func Cors(origin []string, headers []string) negroni.Handler {
 	return negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		w.Header().Set(headerAllowOrigin, strings.Join(origin, ","))
 		w.Header().Set(headerAllowMethods, strings.Join(defaultAllowMethods, ","))
-		w.Header().Set(headerAllowHeaders, "*")
+		w.Header().Set(headerAllowHeaders, strings.Join(headers, ","))
 		w.Header().Set(headerAllowCredentials, strconv.FormatBool(true))
 		if allowed := checkCors(r, origin); !allowed {
 			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 		next(w, r)

--- a/utils.go
+++ b/utils.go
@@ -77,6 +77,7 @@ var defaultAllowMethods = []string{
 	"PUT",
 	"PATCH",
 	"DELETE",
+	"OPTIONS",
 }
 
 const (


### PR DESCRIPTION
Hi,

I've found an issue while trying to use prest with cors. Current implementation do not support preflight (OPTIONS) requests, which are pretty common case with cors. Additionally according to [mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) the wildcard on allow headers is not yet supported therefore I've made it configurable. There is also a related change in the config repo.

Best Regards
Cezary