### PR TITLE
return allowed origin for every method

### DIFF
--- a/middlewares.go
+++ b/middlewares.go
@@ -64,11 +64,11 @@ func JwtMiddleware(key string) negroni.Handler {
 // Cors middleware
 func Cors(origin []string, headers []string) negroni.Handler {
 	return negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		w.Header().Set(headerAllowOrigin, strings.Join(origin, ","))
 		if r.Method == "OPTIONS" && r.Header.Get("Access-Control-Request-Method") != "" {
 			w.Header().Set(headerAllowMethods, strings.Join(defaultAllowMethods, ","))
 			w.Header().Set(headerAllowHeaders, strings.Join(headers, ","))
 			w.Header().Set(headerAllowCredentials, strconv.FormatBool(true))
-			w.Header().Set(headerAllowOrigin, strings.Join(origin, ","))
 			if allowed := checkCors(r, origin); !allowed {
 				w.WriteHeader(http.StatusForbidden)
 				return

--- a/middlewares.go
+++ b/middlewares.go
@@ -65,10 +65,10 @@ func JwtMiddleware(key string) negroni.Handler {
 func Cors(origin []string, headers []string) negroni.Handler {
 	return negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		w.Header().Set(headerAllowOrigin, strings.Join(origin, ","))
+		w.Header().Set(headerAllowCredentials, strconv.FormatBool(true))
 		if r.Method == "OPTIONS" && r.Header.Get("Access-Control-Request-Method") != "" {
 			w.Header().Set(headerAllowMethods, strings.Join(defaultAllowMethods, ","))
 			w.Header().Set(headerAllowHeaders, strings.Join(headers, ","))
-			w.Header().Set(headerAllowCredentials, strconv.FormatBool(true))
 			if allowed := checkCors(r, origin); !allowed {
 				w.WriteHeader(http.StatusForbidden)
 				return


### PR DESCRIPTION
Without this change, prest can't return headers properly for requests when cors is enabled.
I made some tests using Angular 5.1.0. When prest doesn't add origin to the header, I receive an error that Access-Control-Allow-Origin isn't present on response header.

ping @crgimenes @felipeweb @avelino 